### PR TITLE
Update plyr.component.ts

### DIFF
--- a/projects/ngx-plyr/src/lib/plyr/plyr.component.ts
+++ b/projects/ngx-plyr/src/lib/plyr/plyr.component.ts
@@ -165,6 +165,10 @@ export class PlyrComponent implements AfterViewInit, OnChanges, OnDestroy {
       this.driver.destroy({
         plyr: this.player,
       });
+      if (this.vr.nativeElement.plyr) {
+        delete this.vr.nativeElement.plyr;
+        this.vr.nativeElement = this.player.elements.original
+      }
     }
   }
 


### PR DESCRIPTION
whenever changing options, it triggers ngOnChanges lifecycle event which triggers a reinitialization of the player.
after destroyPlayer() method is invoked, `this.videoElement` does not remove the `plyr` instance property from the video element, and the `this.vr.nativeElement` doesn't seem to detect the video element (after destruction). so adding these lines of code fixed the problem