### PR TITLE
call hls.destroy() in hlsjs-plyr-driver

### DIFF
--- a/src/app/hlsjs-plyr-driver/hlsjs-plyr-driver.ts
+++ b/src/app/hlsjs-plyr-driver/hlsjs-plyr-driver.ts
@@ -28,6 +28,7 @@ export class HlsjsPlyrDriver implements PlyrDriver {
   destroy(params: PlyrDriverDestroyParams) {
     params.plyr.destroy();
     this.hls.detachMedia();
+    this.hls.destroy();
   }
 
   load(src: string) {


### PR DESCRIPTION
I've been using ngx-plyr to play HLS video using the example hls driver.

When I destroy the Angular component that my ngx-plyr is in, I see in the network activity my app continues to load the .m3u8 file periodically. 

this change seems to have fixed the problem for me.